### PR TITLE
by_user should take a Boolean and not a String.

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/api/AllCommandsReportBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/AllCommandsReportBuilder.java
@@ -14,5 +14,5 @@ public interface AllCommandsReportBuilder extends InvokableBuilder<AllCommandsRe
 
     public AllCommandsReportBuilder sort_column(String sort_column);
 
-    public AllCommandsReportBuilder by_user(Boolean by_user);
+    public AllCommandsReportBuilder by_user(boolean by_user);
 }

--- a/src/main/java/com/qubole/qds/sdk/java/details/AllCommandsReportBuilderImpl.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/AllCommandsReportBuilderImpl.java
@@ -48,7 +48,7 @@ class AllCommandsReportBuilderImpl extends InvocationCallbackBase<AllCommandsRep
     }
 
     @Override
-    public AllCommandsReportBuilder by_user(Boolean by_user)
+    public AllCommandsReportBuilder by_user(boolean by_user)
     {
         parameters.put("by_user", String.valueOf(by_user));
         return this;


### PR DESCRIPTION
by_user is used to tell the API that you want to see report for
commands submitted only by the current user. By default, the
API returns commands submitted by all users of the current
account.
