### PR TITLE
SDK-37: Java SDK: wait for query to complete after running

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/api/CompositeCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/CompositeCommandBuilder.java
@@ -18,7 +18,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface CompositeCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface CompositeCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public CompositeCommandBuilder name(String commandName);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/DbAdvancedExportCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/DbAdvancedExportCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface DbAdvancedExportCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface DbAdvancedExportCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public DbAdvancedExportCommandBuilder db_table(String db_table);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/DbAdvancedImportCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/DbAdvancedImportCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface DbAdvancedImportCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface DbAdvancedImportCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public DbAdvancedImportCommandBuilder hive_table(String hive_table);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/DbSimpleExportCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/DbSimpleExportCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface DbSimpleExportCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface DbSimpleExportCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public DbSimpleExportCommandBuilder hive_table(String hive_table);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/DbSimpleImportCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/DbSimpleImportCommandBuilder.java
@@ -16,9 +16,8 @@
 package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
-import java.util.Map;
 
-public interface DbSimpleImportCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface DbSimpleImportCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public DbSimpleImportCommandBuilder hive_table(String hive_table);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/HadoopCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/HadoopCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface HadoopCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface HadoopCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public enum SubCommandType
     {

--- a/src/main/java/com/qubole/qds/sdk/java/api/HiveCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/HiveCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface HiveCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface HiveCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public HiveCommandBuilder query(String query);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/InvokableCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/InvokableCommandBuilder.java
@@ -1,0 +1,18 @@
+package com.qubole.qds.sdk.java.api;
+
+import com.qubole.qds.sdk.java.entities.Command;
+
+/**
+ * Terminating method for Commands
+ */
+public interface InvokableCommandBuilder<T> extends InvokableBuilder<T> {
+
+	/**
+     * Invoke the API wait for result return final Command
+     *
+     * @return result
+	 * @throws Exception 
+     */
+    public Command run() throws Exception;
+  
+}

--- a/src/main/java/com/qubole/qds/sdk/java/api/InvokableCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/InvokableCommandBuilder.java
@@ -7,11 +7,11 @@ import com.qubole.qds.sdk.java.entities.Command;
  */
 public interface InvokableCommandBuilder<T> extends InvokableBuilder<T> {
 
-	/**
+    /**
      * Invoke the API wait for result return final Command
      *
      * @return result
-	 * @throws Exception 
+     * @throws Exception 
      */
     public Command run() throws Exception;
   

--- a/src/main/java/com/qubole/qds/sdk/java/api/PigCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/PigCommandBuilder.java
@@ -18,7 +18,7 @@ package com.qubole.qds.sdk.java.api;
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 import java.util.Map;
 
-public interface PigCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface PigCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public PigCommandBuilder script_location(String script_location);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/PrestoCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/PrestoCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface PrestoCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface PrestoCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public PrestoCommandBuilder script_location(String script_location);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/ShellCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/ShellCommandBuilder.java
@@ -19,7 +19,7 @@ import com.qubole.qds.sdk.java.entities.CommandResponse;
 
 import java.util.List;
 
-public interface ShellCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface ShellCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public ShellCommandBuilder inline(String inline);
 

--- a/src/main/java/com/qubole/qds/sdk/java/api/SparkCommandBuilder.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/SparkCommandBuilder.java
@@ -17,7 +17,7 @@ package com.qubole.qds.sdk.java.api;
 
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 
-public interface SparkCommandBuilder extends InvokableBuilder<CommandResponse>
+public interface SparkCommandBuilder extends InvokableCommandBuilder<CommandResponse>
 {
     public SparkCommandBuilder program(String program);
 

--- a/src/main/java/com/qubole/qds/sdk/java/details/CommandBuilderImplBase.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/CommandBuilderImplBase.java
@@ -16,13 +16,13 @@
 package com.qubole.qds.sdk.java.details;
 
 import com.qubole.qds.sdk.java.api.BaseCommand;
-import com.qubole.qds.sdk.java.api.InvokableBuilder;
+import com.qubole.qds.sdk.java.api.InvokableCommandBuilder;
 import com.qubole.qds.sdk.java.client.QdsClient;
 import com.qubole.qds.sdk.java.entities.CommandResponse;
 import org.codehaus.jackson.node.ObjectNode;
 import java.io.IOException;
 
-abstract class CommandBuilderImplBase extends InvocationCallbackBase<CommandResponse> implements InvokableBuilder<CommandResponse>
+abstract class CommandBuilderImplBase extends InvocationCommandCallbackBase<CommandResponse> implements InvokableCommandBuilder<CommandResponse>
 {
     private final QdsClient client;
     private final RequestDetails.Method method;
@@ -60,6 +60,8 @@ abstract class CommandBuilderImplBase extends InvocationCallbackBase<CommandResp
         BaseCommandImpl command = new BaseCommandImpl(getCommandType(), cmdNode);
         return command;
     }
+    
+    
 
     protected CommandBuilderImplBase(QdsClient client)
     {

--- a/src/main/java/com/qubole/qds/sdk/java/details/InvocationCallbackBase.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/InvocationCallbackBase.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
 
 abstract class InvocationCallbackBase<T> implements InvokableBuilder<T>
 {
-    private InvocationCallback<T> callback;
+    protected InvocationCallback<T> callback;
 
     public InvokableBuilder<T> withCallback(InvocationCallback<T> callback)
     {

--- a/src/main/java/com/qubole/qds/sdk/java/details/InvocationCommandCallbackBase.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/InvocationCommandCallbackBase.java
@@ -1,0 +1,24 @@
+package com.qubole.qds.sdk.java.details;
+
+import java.util.concurrent.Future;
+import com.qubole.qds.sdk.java.api.InvokableCommandBuilder;
+import com.qubole.qds.sdk.java.client.ResultLatch;
+import com.qubole.qds.sdk.java.entities.Command;
+import com.qubole.qds.sdk.java.entities.CommandResponse;
+
+public abstract class InvocationCommandCallbackBase<T> extends InvocationCallbackBase<T> implements InvokableCommandBuilder<T> {
+	
+	public Command run() throws Exception{
+	    	
+	    	InvokeArguments<T> invokeArguments = getInvokeArguments();
+	    	
+	    	Future<T> futureResponse=invokeArguments.getClient().invokeRequest(invokeArguments.getForPage(), invokeArguments.getEntity(), invokeArguments.getResponseType(), invokeArguments.getAdditionalPaths());
+	    	
+	    	CommandResponse cr=(CommandResponse)futureResponse.get();
+	    	
+	    	new ResultLatch(invokeArguments.getClient(), cr.getId()).awaitResult();
+	    	
+	        return invokeArguments.getClient().command().status(String.valueOf(cr.getId())).invoke().get();
+	}
+	
+}


### PR DESCRIPTION
Added run method that will: run a command and wait until it completes execution and then return final Command.
Similar to run() in python SDK

Extended the InvokableBuilder for commands with InvokableCommandBuilder and added the run method here so that it is available for all Command types