### PR TITLE
SDK-34: JAVA SDK: set a limit on minimum polling interval

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/client/ResultLatch.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/ResultLatch.java
@@ -18,11 +18,13 @@ package com.qubole.qds.sdk.java.client;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.qubole.qds.sdk.java.entities.ResultValue;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
 
 /**
  * A utility for polling for a command result. Allows for blocking or
@@ -35,7 +37,9 @@ public class ResultLatch
     private final AtomicLong pollMs = new AtomicLong(DEFAULT_POLL_MS);
 
     private static final ExecutorService executorService = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("ResultLatch-%d").setDaemon(true).build());
-
+    
+    private static final Logger log = Logger.getLogger(ResultLatch.class.getName());
+    
     private static final int DEFAULT_POLL_MS = 5000;
     private static final int MIN_POLL_INTERVAL_MS = 1000;
 
@@ -71,12 +75,15 @@ public class ResultLatch
      */
     public void setPollSleep(long time, TimeUnit unit)
     {
-    	if(unit.toMillis(time)<MIN_POLL_INTERVAL_MS){
-    		pollMs.set(MIN_POLL_INTERVAL_MS);
-    	}
-    	else{
-    		pollMs.set(unit.toMillis(time));
-    	}
+        if ( unit.toMillis(time) < MIN_POLL_INTERVAL_MS )
+        {
+            log.warning(String.format("Poll interval cannot be less than %d seconds. Setting it to %d seconds.", TimeUnit.MILLISECONDS.toSeconds(MIN_POLL_INTERVAL_MS), TimeUnit.MILLISECONDS.toSeconds(MIN_POLL_INTERVAL_MS)));
+    	    pollMs.set(MIN_POLL_INTERVAL_MS);
+        }
+        else
+        {
+    	    pollMs.set(unit.toMillis(time));
+        }
     }
 
     /**

--- a/src/main/java/com/qubole/qds/sdk/java/client/ResultLatch.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/ResultLatch.java
@@ -18,7 +18,6 @@ package com.qubole.qds.sdk.java.client;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.qubole.qds.sdk.java.entities.ResultValue;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +77,7 @@ public class ResultLatch
         if ( unit.toMillis(time) < MIN_POLL_INTERVAL_MS )
         {
             log.warning(String.format("Poll interval cannot be less than %d seconds. Setting it to %d seconds.", TimeUnit.MILLISECONDS.toSeconds(MIN_POLL_INTERVAL_MS), TimeUnit.MILLISECONDS.toSeconds(MIN_POLL_INTERVAL_MS)));
-    	    pollMs.set(MIN_POLL_INTERVAL_MS);
+            pollMs.set(MIN_POLL_INTERVAL_MS);
         }
         else
         {

--- a/src/main/java/com/qubole/qds/sdk/java/client/ResultLatch.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/ResultLatch.java
@@ -37,6 +37,7 @@ public class ResultLatch
     private static final ExecutorService executorService = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("ResultLatch-%d").setDaemon(true).build());
 
     private static final int DEFAULT_POLL_MS = 5000;
+    private static final int MIN_POLL_INTERVAL_MS = 1000;
 
     private static final String STATUS_DONE = "done";
     private static final String STATUS_WAITING = "waiting";
@@ -70,7 +71,12 @@ public class ResultLatch
      */
     public void setPollSleep(long time, TimeUnit unit)
     {
-        pollMs.set(unit.toMillis(time));
+    	if(unit.toMillis(time)<MIN_POLL_INTERVAL_MS){
+    		pollMs.set(MIN_POLL_INTERVAL_MS);
+    	}
+    	else{
+    		pollMs.set(unit.toMillis(time));
+    	}
     }
 
     /**


### PR DESCRIPTION
Setting minimum poll interval to 1 second.
If anything less than this is specified then it defaults to 1 second.