### PR TITLE
SDK-33:ensure Java SDK comply with backoff requirements in our new SLA

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -16,13 +16,12 @@
 package com.qubole.qds.sdk.java.details;
 
 import com.qubole.qds.sdk.java.client.retry.RetrySleeper;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public class ExponentialBackoffRetry implements RetrySleeper
 {
-    private final Random random = new Random();
     private final long baseSleepTimeMs;
+    private final long MAX_DELAY=32000;
 
     public ExponentialBackoffRetry()
     {
@@ -37,7 +36,10 @@ public class ExponentialBackoffRetry implements RetrySleeper
     @Override
     public void sleep(int retryCount) throws InterruptedException
     {
-        long sleepMs = baseSleepTimeMs * Math.max(1, random.nextInt(1 << (retryCount + 1)));
+    	long sleepMs = (long) (baseSleepTimeMs * Math.pow(2, retryCount));
+    	if(sleepMs > MAX_DELAY){
+    		sleepMs = MAX_DELAY;
+    	}
         TimeUnit.MILLISECONDS.sleep(sleepMs);
     }
 }

--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -21,11 +21,10 @@ import java.util.concurrent.TimeUnit;
 public class ExponentialBackoffRetry implements RetrySleeper
 {
     private final long baseSleepTimeMs;
-    private final long MAX_DELAY=32000;
 
     public ExponentialBackoffRetry()
     {
-        this(1000);
+        this(30000);
     }
 
     public ExponentialBackoffRetry(long baseSleepTimeMs)
@@ -36,10 +35,7 @@ public class ExponentialBackoffRetry implements RetrySleeper
     @Override
     public void sleep(int retryCount) throws InterruptedException
     {
-    	long sleepMs = (long) (baseSleepTimeMs * Math.pow(2, retryCount));
-    	if(sleepMs > MAX_DELAY){
-    		sleepMs = MAX_DELAY;
-    	}
+        long sleepMs = (long) (baseSleepTimeMs * Math.pow(2, retryCount));
         TimeUnit.MILLISECONDS.sleep(sleepMs);
     }
 }

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetry.java
@@ -21,9 +21,19 @@ import com.qubole.qds.sdk.java.client.retry.RetrySleeper;
 
 public class StandardRetry implements Retry
 {
-    private final RetrySleeper retrySleeper = new ExponentialBackoffRetry();
-    private final RetryPolicy retryPolicy = new StandardRetryPolicy();
-
+    private RetrySleeper retrySleeper = new ExponentialBackoffRetry();
+    private RetryPolicy retryPolicy = new StandardRetryPolicy();
+    
+    public StandardRetry(){
+        this.retrySleeper = new ExponentialBackoffRetry();
+        this.retryPolicy = new StandardRetryPolicy();
+    }
+    
+    public StandardRetry(long exponentialBackOffBasetime, int maxRetriesPolicy){
+        this.retrySleeper = new ExponentialBackoffRetry(exponentialBackOffBasetime);
+        this.retryPolicy = new StandardRetryPolicy(maxRetriesPolicy);
+    }
+    
     @Override
     public RetrySleeper getRetrySleeper()
     {

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -29,7 +29,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     private final int maxRetries;
 
-    private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final int DEFAULT_MAX_RETRIES = 11;
 
     public StandardRetryPolicy()
     {

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -29,7 +29,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     private final int maxRetries;
 
-    private static final int DEFAULT_MAX_RETRIES = 11;
+    private static final int DEFAULT_MAX_RETRIES = 5;
 
     public StandardRetryPolicy()
     {

--- a/src/test/java/com/qubole/qds/sdk/java/TestRetries.java
+++ b/src/test/java/com/qubole/qds/sdk/java/TestRetries.java
@@ -98,7 +98,7 @@ public class TestRetries
                 };
             }
         };
-        DefaultQdsConfiguration configuration = new DefaultQdsConfiguration("http://localhost:" + TEST_PORT, "bar", clientConfig, new StandardRetry(), retryConnectorAllocator);
+        DefaultQdsConfiguration configuration = new DefaultQdsConfiguration("http://localhost:" + TEST_PORT, "bar", clientConfig, new StandardRetry(1000,3), retryConnectorAllocator);
         QdsClient client = new QdsClientImpl(configuration);
         try
         {
@@ -143,7 +143,7 @@ public class TestRetries
                 };
             }
         };
-        DefaultQdsConfiguration configuration = new DefaultQdsConfiguration("http://localhost:" + TEST_PORT, "bar", clientConfig, new StandardRetry(), retryConnectorAllocator);
+        DefaultQdsConfiguration configuration = new DefaultQdsConfiguration("http://localhost:" + TEST_PORT, "bar", clientConfig, new StandardRetry(1000,3), retryConnectorAllocator);
         QdsClient client = new QdsClientImpl(configuration);
         String value = client.command().logs("100").invoke().get();  // logs is set to retry
         Assert.assertTrue(hadRetry.get());
@@ -175,7 +175,7 @@ public class TestRetries
                 };
             }
         };
-        DefaultQdsConfiguration configuration = new DefaultQdsConfiguration("http://localhost:" + TEST_PORT, "bar", new ClientConfig(), new StandardRetry(), retryConnectorAllocator);
+        DefaultQdsConfiguration configuration = new DefaultQdsConfiguration("http://localhost:" + TEST_PORT, "bar", new ClientConfig(), new StandardRetry(1000,3), retryConnectorAllocator);
         QdsClient client = new QdsClientImpl(configuration);
         String value = client.command().logs("100").invoke().get();  // logs is set to retry
         Assert.assertTrue(hadRetry.get());


### PR DESCRIPTION
Back off requirements to match our SLA
11 retries with following timeout sequence:
1, 2, 4, 8, 16, 32, 32, 32, 32, 32, 32.
The total retry time of these 3.71 minutes.