### PR TITLE
SDK-72: Added missing dependencies used for relocation when creating shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,18 @@
                                     <shadedPattern>hidden.commons-codec</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.fasterxml.jackson.databind</pattern>
+                                    <shadedPattern>hidden.com.fasterxml.jackson.databind</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.annotation</pattern>
+                                    <shadedPattern>hidden.com.fasterxml.jackson.annotation</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.dataformat.cbor</pattern>
+                                    <shadedPattern>hidden.com.fasterxml.jackson.dataformat.cbor</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.fasterxml.jackson.core</pattern>
                                     <shadedPattern>hidden.com.fasterxml.jackson.core</shadedPattern>
                                 </relocation>


### PR DESCRIPTION
The SDK has some dependencies that can conflict with Jersey 2.0. To resolve this, an option to create a shaded JAR is provided[here](https://github.com/qubole/qds-sdk-java#jersey-20).  

Creating a shaded JAR file includes all the dependencies of the SDK in a single JAR while modifying the namespace of the included dependencies to avoid conflict. However, not all dependencies are relocated in the POM file; dependencies with the namespace `com.fasterxml.jackson` are missed.  

The above issue throws the following exception in the `ResultStreamer` class when the results of the query are returned in an S3 file format:
```
Exception in thread "main" java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.ObjectMapper.configure(Lhidden/com/fasterxml/jackson/core/JsonParser$Feature;Z)Lcom/fasterxml/jackson/databind/ObjectMapper;
    at hidden.com.amazonaws.internal.config.InternalConfig.<clinit>(InternalConfig.java:43)
    at hidden.com.amazonaws.internal.config.InternalConfig$Factory.<clinit>(InternalConfig.java:304)
    at hidden.com.amazonaws.util.VersionInfoUtils.userAgent(VersionInfoUtils.java:139)
    at hidden.com.amazonaws.util.VersionInfoUtils.initializeUserAgent(VersionInfoUtils.java:134)
    at hidden.com.amazonaws.util.VersionInfoUtils.getUserAgent(VersionInfoUtils.java:95)
    at hidden.com.amazonaws.ClientConfiguration.<clinit>(ClientConfiguration.java:60)
    at hidden.com.amazonaws.ClientConfigurationFactory.getDefaultConfig(ClientConfigurationFactory.java:46)
    at hidden.com.amazonaws.ClientConfigurationFactory.getConfig(ClientConfigurationFactory.java:35)
    at hidden.com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:304)
    at com.qubole.qds.sdk.java.client.ResultStreamer.newS3Client(ResultStreamer.java:117)
```

Adding the missing dependencies for relocation in the POM file.

Fixes issue: https://github.com/qubole/qds-sdk-java/issues/72