### PR TITLE
SDK-148: Add log messages for non-200 response

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/client/ErrorResponseFilter.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/ErrorResponseFilter.java
@@ -8,8 +8,11 @@ import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.Response;
 import java.io.InputStreamReader;
+import java.util.logging.Logger;
 
 public class ErrorResponseFilter implements ClientResponseFilter {
+
+    private static final Logger LOG = Logger.getLogger(ErrorResponseFilter.class.getName());
 
     @Override
     public void filter(final ClientRequestContext requestContext,
@@ -18,12 +21,15 @@ public class ErrorResponseFilter implements ClientResponseFilter {
             // For non-200 response, log the custom error message.
             if (responseContext.getStatus() != Response.Status.OK.getStatusCode()) {
                 if (responseContext.hasEntity()) {
-                    System.err.println(CharStreams.toString(
-                            new InputStreamReader(responseContext.getEntityStream(), Charsets.UTF_8)));
+                    String error = CharStreams.toString(
+                        new InputStreamReader(responseContext.getEntityStream(), Charsets.UTF_8));
+                    LOG.severe(error);
+                    System.err.println(error);
                 }
             }
         } catch (Exception e) {
             // Silently pass. We don't want anything to fail because of this filter.
+            LOG.warning("Error while checking response code: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/qubole/qds/sdk/java/client/UserAgentFilter.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/UserAgentFilter.java
@@ -5,8 +5,11 @@ import javax.ws.rs.client.ClientRequestFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 public class UserAgentFilter implements ClientRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(UserAgentFilter.class.getName());
 
     public String version;
 
@@ -20,12 +23,16 @@ public class UserAgentFilter implements ClientRequestFilter {
             if (inputStream != null) {
                 prop.load(inputStream);
             } else {
-                System.err.println("Version Info file '" + propFileName + "' not found in the classpath");
+                String error = "Version Info file '" + propFileName + "' not found in the classpath";
+                LOG.severe(error);
+                System.err.println(error);
             }
 
             version = prop.getProperty("version");
         } catch (Exception e) {
-            System.err.println("Some error while loading the version info for user-agent string.");
+            String error = "Some error while loading the version info for user-agent string.";
+            LOG.severe(error);
+            System.err.println(error);
         }
     }
 


### PR DESCRIPTION
Currently, we have error response filter which writes to standard error when non-200 response is received. This change also logs it. 