### PR TITLE
Issue #106: JDK 11 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,158 @@
+!.mvn/wrapper/maven-wrapper.jar
+temp/
+
+#---------------------------------------#
+# STS and Eclipse                       #
+#---------------------------------------#
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+
+#---------------------------------------#
+# IntelliJ IDEA                         #
+#---------------------------------------#
+.idea
+*.iws
+*.iml
+*.ipr
+.idea/
+
+#---------------------------------------#
+# NetBeans                              #
+#---------------------------------------#
+nbproject/private/
+build/
+!config/build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+#---------------------------------------#
+# Project Ignores                       #
+#---------------------------------------#
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+!/.mvn/wrapper/maven-wrapper.jar
+
+# Compiled class file
+*.class
+
+#---------------------------------------#
+# Mobile Tools for Java (J2ME)          #
+#---------------------------------------#
+.mtj.tmp/
+
+#---------------------------------------#
+# Package Files                         #
+#---------------------------------------#
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+#---------------------------------------#
+# virtual machine crash logs            #
+#---------------------------------------#
+hs_err_pid*
+
+#---------------------------------------#
+# Misc                                  #
+#---------------------------------------#
+*.log
+log/
+logs/
+
+#---------------------------------------#
+# Sublime Text                          #
+#---------------------------------------#
+
+/*.sublime*
+.sublime-gulp.cache
+
+# VS Code
+/.vscode
+
+#---------------------------------------#
+# Netbeans Ignores                      #
+#---------------------------------------#
+nbactions*.xml
+nb-configuration*.xml
+
+# BlueJ
+*.ctxt
+
+
+#---------------------------------------#
+# General Ignores                       #
+#---------------------------------------#
+
+*~
+*.orig
+.vagrant
+
+
+#---------------------------------------#
+# Linux Ignores                         #
+#---------------------------------------#
+
+# KDE directory preferences
+.directory
+
+
+#---------------------------------------#
+# OSX Ignores                           #
+#---------------------------------------#
+
+.DS_Store
+.AppleDouble
+.LSOverride
+.localized
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+#---------------------------------------#
+# Windows Ignores                       #
+#---------------------------------------#
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <jackson.version>2.9.7</jackson.version>
         <testng-version>6.14.3</testng-version>
         <aws-java-sdk-version>1.10.77</aws-java-sdk-version>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>
@@ -117,7 +118,6 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.6</version>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -125,10 +125,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -341,6 +341,20 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk11-compliant</id>
+            <properties>
+                <java.version>11</java.version>
+                <javax-activation-version>1.1.1</javax-activation-version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                    <version>${javax-activation-version}</version>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 


### PR DESCRIPTION
**Issue #106** 

Added maven profile: `jdk11-compliant` that builds the library with java 11.
By default the applications is built with java 8.
The command to use is:
`mvn clean install -P jdk11-compliant`