### PR TITLE
new:dev:SDK-375:Log Trace ID of all HTTP Requests in SDK

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/client/ErrorResponseFilter.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/ErrorResponseFilter.java
@@ -23,6 +23,11 @@ public class ErrorResponseFilter implements ClientResponseFilter {
                 if (responseContext.hasEntity()) {
                     String error = CharStreams.toString(
                         new InputStreamReader(responseContext.getEntityStream(), Charsets.UTF_8));
+                    //Add trace_id support
+                    String trace_id = responseContext.getHeaderString('X-Qubole-Trace-Id');
+                    String display_message = "Request ID is '" + trace_id + "' .Please share it with Qubole Support team for any assistance";
+                    LOG.severe(display_message);
+                    System.err.println(display_message);
                     LOG.severe(error);
                     System.err.println(error);
                 }

--- a/src/main/java/com/qubole/qds/sdk/java/client/ErrorResponseFilter.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/ErrorResponseFilter.java
@@ -24,10 +24,12 @@ public class ErrorResponseFilter implements ClientResponseFilter {
                     String error = CharStreams.toString(
                         new InputStreamReader(responseContext.getEntityStream(), Charsets.UTF_8));
                     //Add trace_id support
-                    String trace_id = responseContext.getHeaderString('X-Qubole-Trace-Id');
-                    String display_message = "Request ID is '" + trace_id + "' .Please share it with Qubole Support team for any assistance";
-                    LOG.severe(display_message);
-                    System.err.println(display_message);
+                    String traceId = responseContext.getHeaderString("X-Qubole-Trace-Id");
+                    if (traceId != null && !traceId.isEmpty()){
+                        String displayMessage = "Request ID is '" + traceId + "' .Please share it with Qubole Support team for any assistance";
+                        LOG.severe(displayMessage);
+                        System.err.println(displayMessage);
+                    }
                     LOG.severe(error);
                     System.err.println(error);
                 }
@@ -37,5 +39,4 @@ public class ErrorResponseFilter implements ClientResponseFilter {
             LOG.warning("Error while checking response code: " + e.getMessage());
         }
     }
-
 }


### PR DESCRIPTION
As part of requirement, we have added support for Qubole_Trace_Id message in case of failures.

sample err message- 
Dec 18, 2019 11:45:13 AM com.qubole.qds.sdk.java.client.ErrorResponseFilter filter
SEVERE: Request ID is '4742608-1-1576649713.764' .Please share it with Qubole Support team for any assistance
Request ID is '4742608-1-1576649713.764' .Please share it with Qubole Support team for any assistance
Dec 18, 2019 11:45:13 AM com.qubole.qds.sdk.java.client.ErrorResponseFilter filter
SEVERE: {"error":{"error_code":401,"error_message":"Invalid Token"}}
{"error":{"error_code":401,"error_message":"Invalid Token"}}