### PR TITLE
new:dev:INFRA-2843:Add Retries and Delay Options in java-sdk

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -84,6 +84,17 @@ public class DefaultQdsConfiguration implements QdsConfiguration
         this(apiEndpoint, apiToken, apiVersion, jerseyConfiguration, new StandardRetry(), newRetryConnectorAllocator());
     }
 
+    public DefaultQdsConfiguration(String apiEndpoint, int max_retries, int base_retry_delay)
+    {
+        if (max_retries > 5){
+            max_retries = 5;
+        }
+        if (base_retry_delay > 10){
+            base_retry_delay = 10;
+        }
+        this(apiEndpoint, apiToken, apiVersion, null, new StandardRetry((long)TimeUnit.SECONDS.toMillis(base_retry_delay), max_retries), newRetryConnectorAllocator());
+    }
+
     @VisibleForTesting
     public interface RetryConnectorAllocator
     {

--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -93,7 +93,7 @@ public class DefaultQdsConfiguration implements QdsConfiguration
 
     public DefaultQdsConfiguration(String apiEndpoint, String apiToken, int maxRetries, int baseRetryDelay)
     {
-        this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry((long) TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
+        this(apiEndpoint, apiToken, API_VERSION, null, new StandardRetry((long) TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
     }
 
     @VisibleForTesting

--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -87,7 +87,7 @@ public class DefaultQdsConfiguration implements QdsConfiguration
     /**
      * @param apiEndpoint endpoint
      * @param apiToken your API token
-     * @param maxRetries number of re-attempts for an api-call in case of retryable exceptions. defaults to 5.
+     * @param maxRetries number of re-attempts for an api-call in case of retryable exceptions. defaults to 6.
      * @param baseRetryDelay base sleep interval for exponential backoff in case of retryable exceptions. defaults to 10s.
      */
 

--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -84,16 +84,25 @@ public class DefaultQdsConfiguration implements QdsConfiguration
         this(apiEndpoint, apiToken, apiVersion, jerseyConfiguration, new StandardRetry(), newRetryConnectorAllocator());
     }
 
-    public DefaultQdsConfiguration(String apiEndpoint, int max_retries, int base_retry_delay)
+    /**
+     * @param apiEndpoint endpoint
+     * @param apiToken your API token
+     * @param maxRetries number of re-attempts for an api-call in case of retryable exceptions. defaults to 5.
+     * @param baseRetryDelay base sleep interval for exponential backoff in case of retryable exceptions. defaults to 10s.
+     */
+
+    public DefaultQdsConfiguration(String apiEndpoint, String apiToken, int maxRetries, int baseRetryDelay)
     {
-        if (max_retries > 5){
-            max_retries = 5;
+        if (maxRetries > 5){
+            maxRetries = 5;
         }
-        if (base_retry_delay > 10){
-            base_retry_delay = 10;
+        if (baseRetryDelay > 10){
+            baseRetryDelay = 10;
         }
-        this(apiEndpoint, apiToken, apiVersion, null, new StandardRetry((long)TimeUnit.SECONDS.toMillis(base_retry_delay), max_retries), newRetryConnectorAllocator());
+        this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry((long)TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
     }
+
+    
 
     @VisibleForTesting
     public interface RetryConnectorAllocator

--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -93,12 +93,6 @@ public class DefaultQdsConfiguration implements QdsConfiguration
 
     public DefaultQdsConfiguration(String apiEndpoint, String apiToken, int maxRetries, int baseRetryDelay)
     {
-        if (maxRetries > 5){
-            maxRetries = 5;
-        }
-        if (baseRetryDelay > 10){
-            baseRetryDelay = 10;
-        }
         this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry((long) TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
     }
 

--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -99,7 +99,7 @@ public class DefaultQdsConfiguration implements QdsConfiguration
         if (baseRetryDelay > 10){
             baseRetryDelay = 10;
         }
-        this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry( (long) TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
+        this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry((long) TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
     }
 
     @VisibleForTesting

--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -99,10 +99,8 @@ public class DefaultQdsConfiguration implements QdsConfiguration
         if (baseRetryDelay > 10){
             baseRetryDelay = 10;
         }
-        this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry((long)TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
+        this(api_endpoint, apiToken, API_VERSION, null, new StandardRetry( (long) TimeUnit.SECONDS.toMillis(baseRetryDelay), maxRetries), newRetryConnectorAllocator());
     }
-
-    
 
     @VisibleForTesting
     public interface RetryConnectorAllocator

--- a/src/main/java/com/qubole/qds/sdk/java/client/retry/RetryConnector.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/retry/RetryConnector.java
@@ -84,7 +84,8 @@ public class RetryConnector implements Connector
         {
             if (tryRetry(request, tryCount, null, e))
             {
-                return internalApply(request, tryCount + 1);
+                ClientRequest retryRequest = new ClientRequest(request);
+                return internalApply(retryRequest, tryCount + 1);
             }
             throw e;
         }
@@ -93,7 +94,8 @@ public class RetryConnector implements Connector
         {
             if (tryRetry(request, tryCount, clientResponse, null))
             {
-                return internalApply(request, tryCount + 1);
+                ClientRequest retryRequest = new ClientRequest(request);
+                return internalApply(retryRequest, tryCount + 1);
             }
         }
 
@@ -142,7 +144,8 @@ public class RetryConnector implements Connector
                 }
             }
         };
-        connector.apply(request, localCallback);
+        ClientRequest retryRequest = new ClientRequest(request);
+        connector.apply(retryRequest, localCallback);
         return SettableFuture.create(); // just a dummy
     }
 

--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -17,9 +17,11 @@ package com.qubole.qds.sdk.java.details;
 
 import com.qubole.qds.sdk.java.client.retry.RetrySleeper;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 public class ExponentialBackoffRetry implements RetrySleeper
 {
+    private static final Logger LOG = Logger.getLogger(ExponentialBackoffRetry.class.getName());
     private final long baseSleepTimeMs;
 
     public ExponentialBackoffRetry()
@@ -36,6 +38,7 @@ public class ExponentialBackoffRetry implements RetrySleeper
     public void sleep(int retryCount) throws InterruptedException
     {
         long sleepMs = (long) (baseSleepTimeMs * Math.pow(2, retryCount));
+        LOG.info(String.format("Sleeping before retry for %d seconds..", sleepMs/1000));
         TimeUnit.MILLISECONDS.sleep(sleepMs);
     }
 }

--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -24,7 +24,7 @@ public class ExponentialBackoffRetry implements RetrySleeper
 
     public ExponentialBackoffRetry()
     {
-        this(30000);
+        this(10000);
     }
 
     public ExponentialBackoffRetry(long baseSleepTimeMs)

--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -28,7 +28,7 @@ public class ExponentialBackoffRetry implements RetrySleeper
     }
 
     public ExponentialBackoffRetry(long baseSleepTimeMs)
-    {   
+    {
         if (baseSleepTimeMs > 10000){
             this.baseSleepTimeMs = 10000;
         }

--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -29,12 +29,7 @@ public class ExponentialBackoffRetry implements RetrySleeper
 
     public ExponentialBackoffRetry(long baseSleepTimeMs)
     {
-        if (baseSleepTimeMs > 10000){
-            this.baseSleepTimeMs = 10000;
-        }
-        else {
-            this.baseSleepTimeMs = baseSleepTimeMs;
-        }
+        this.baseSleepTimeMs = Math.min(10000, baseSleepTimeMs);
     }
 
     @Override

--- a/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/ExponentialBackoffRetry.java
@@ -28,8 +28,13 @@ public class ExponentialBackoffRetry implements RetrySleeper
     }
 
     public ExponentialBackoffRetry(long baseSleepTimeMs)
-    {
-        this.baseSleepTimeMs = baseSleepTimeMs;
+    {   
+        if (baseSleepTimeMs > 10000){
+            this.baseSleepTimeMs = 10000;
+        }
+        else {
+            this.baseSleepTimeMs = baseSleepTimeMs;
+        }
     }
 
     @Override

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -38,12 +38,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     public StandardRetryPolicy(int maxRetries)
     {
-        if (maxRetries > 5) {
-            this.maxRetries = 5;
-        }
-        else{
-            this.maxRetries = maxRetries;
-        }
+        this. maxRetries = Math.min(5, maxRetries);
     }
 
     @SuppressWarnings("SimplifiableIfStatement")

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -69,10 +69,9 @@ public class StandardRetryPolicy implements RetryPolicy
             int responseStatus = response.getStatus();
             if (responseStatus == 429 || responseStatus == 502 || responseStatus == 503 || responseStatus == 504)
             {
-                LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s",responseStatus, retryCount, uri));
+                LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s", responseStatus, retryCount, uri));
                 return true;
-            }
-        
+            }        
         }
         return shouldBeRetried(uri, exception, mode);
     }

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -71,7 +71,7 @@ public class StandardRetryPolicy implements RetryPolicy
             {
                 LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s", responseStatus, retryCount, uri));
                 return true;
-            }        
+            }
         }
         return shouldBeRetried(uri, exception, mode);
     }

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -62,7 +62,7 @@ public class StandardRetryPolicy implements RetryPolicy
         if (response != null)
         {
             int responseStatus = response.getStatus();
-            if (responseStatus == 429 || responseStatus == 502 || responseStatus == 503 || responseStatus == 504)
+            if (responseStatus == 429 || responseStatus == 503)
             {
                 LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s", responseStatus, retryCount+1, uri));
                 return true;

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -38,7 +38,12 @@ public class StandardRetryPolicy implements RetryPolicy
 
     public StandardRetryPolicy(int maxRetries)
     {
-        this.maxRetries = maxRetries;
+        if (maxRetries > 5) {
+            this.maxRetries = 5;
+        }
+        else{
+            this.maxRetries = maxRetries;
+        }
     }
 
     @SuppressWarnings("SimplifiableIfStatement")

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -29,7 +29,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     private final int maxRetries;
 
-    private static final int DEFAULT_MAX_RETRIES = 5;
+    private static final int DEFAULT_MAX_RETRIES = 6;
 
     public StandardRetryPolicy()
     {
@@ -38,7 +38,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     public StandardRetryPolicy(int maxRetries)
     {
-        this.maxRetries = Math.min(5, maxRetries);
+        this.maxRetries = Math.min(6, maxRetries);
     }
 
     @SuppressWarnings("SimplifiableIfStatement")
@@ -47,7 +47,7 @@ public class StandardRetryPolicy implements RetryPolicy
     {
         if (retryCount >= maxRetries)
         {
-            LOG.warning(String.format("Retries exceeded. retryCount: %d - maxRetries: %d", retryCount, maxRetries));
+            LOG.warning(String.format("Retries exceeded. retryCount: %d - maxRetries: %d", retryCount+1, maxRetries));
             return false;
         }
 
@@ -55,7 +55,7 @@ public class StandardRetryPolicy implements RetryPolicy
         {
             if (response.getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR)
             {
-                LOG.info(String.format("Retrying request due to Status %d. retryCount: %d - request: %s", response.getStatus(), retryCount, uri));
+                LOG.info(String.format("Retrying request due to Status %d. retryCount: %d - request: %s", response.getStatus(), retryCount+1, uri));
                 return true;
             }
         }
@@ -64,7 +64,7 @@ public class StandardRetryPolicy implements RetryPolicy
             int responseStatus = response.getStatus();
             if (responseStatus == 429 || responseStatus == 502 || responseStatus == 503 || responseStatus == 504)
             {
-                LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s", responseStatus, retryCount, uri));
+                LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s", responseStatus, retryCount+1, uri));
                 return true;
             }
         }

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -38,7 +38,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     public StandardRetryPolicy(int maxRetries)
     {
-        this. maxRetries = Math.min(5, maxRetries);
+        this.maxRetries = Math.min(5, maxRetries);
     }
 
     @SuppressWarnings("SimplifiableIfStatement")

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -64,6 +64,16 @@ public class StandardRetryPolicy implements RetryPolicy
                 return true;
             }
         }
+        if (response != null)
+        {
+            int responseStatus = response.getStatus();
+            if (responseStatus == 429 || responseStatus == 502 || responseStatus == 503 || responseStatus == 504)
+            {
+                LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s",responseStatus, retryCount, uri));
+                return true;
+            }
+        
+        }
         return shouldBeRetried(uri, exception, mode);
     }
 

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -50,21 +50,22 @@ public class StandardRetryPolicy implements RetryPolicy
             LOG.warning(String.format("Retries exceeded. retryCount: %d - maxRetries: %d", retryCount+1, maxRetries));
             return false;
         }
-
-        if ((response != null) && (mode == Mode.RETRY_ALL))
-        {
-            if (response.getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR)
-            {
-                LOG.info(String.format("Retrying request due to Status %d. retryCount: %d - request: %s", response.getStatus(), retryCount+1, uri));
-                return true;
-            }
-        }
+        /* Always retry on 429 and 503 error codes irrespective of HTTP method type */
         if (response != null)
         {
             int responseStatus = response.getStatus();
             if (responseStatus == 429 || responseStatus == 503)
             {
                 LOG.info(String.format("Retrying request due to status %d, retryCount: %d - request: %s", responseStatus, retryCount+1, uri));
+                return true;
+            }
+        }
+
+        if ((response != null) && (mode == Mode.RETRY_ALL))
+        {
+            if (response.getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR)
+            {
+                LOG.info(String.format("Retrying request due to Status %d. retryCount: %d - request: %s", response.getStatus(), retryCount+1, uri));
                 return true;
             }
         }


### PR DESCRIPTION
As part of API throttling phase-2 dev, we are extending the capability of retries and base-delay as user-configurable parameters which can be consumed in case of Retryable Exceptions