### PR TITLE
fix: dev: SDK-393: Retries not working in qds-java-sdk

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/client/retry/RetryConnector.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/retry/RetryConnector.java
@@ -84,7 +84,8 @@ public class RetryConnector implements Connector
         {
             if (tryRetry(request, tryCount, null, e))
             {
-                return internalApply(request, tryCount + 1);
+                ClientRequest retryRequest = new ClientRequest(request);
+                return internalApply(retryRequest, tryCount + 1);
             }
             throw e;
         }
@@ -93,7 +94,8 @@ public class RetryConnector implements Connector
         {
             if (tryRetry(request, tryCount, clientResponse, null))
             {
-                return internalApply(request, tryCount + 1);
+                ClientRequest retryRequest = new ClientRequest(request);
+                return internalApply(retryRequest, tryCount + 1);
             }
         }
 
@@ -142,7 +144,8 @@ public class RetryConnector implements Connector
                 }
             }
         };
-        connector.apply(request, localCallback);
+        ClientRequest retryRequest = new ClientRequest(request);
+        connector.apply(retryRequest, localCallback);
         return SettableFuture.create(); // just a dummy
     }
 


### PR DESCRIPTION
When retries are being attempted, exception is thrown
java.lang.IllegalStateException: The output stream has already been closed.
Creating new request object for retry so that attempt to access stream after use is not made