### PR TITLE
fix:dev:INFRA-2843: Updating number of retries 

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
+++ b/src/main/java/com/qubole/qds/sdk/java/client/DefaultQdsConfiguration.java
@@ -87,7 +87,7 @@ public class DefaultQdsConfiguration implements QdsConfiguration
     /**
      * @param apiEndpoint endpoint
      * @param apiToken your API token
-     * @param maxRetries number of re-attempts for an api-call in case of retryable exceptions. defaults to 6.
+     * @param maxRetries number of re-attempts for an api-call in case of retryable exceptions. defaults to 7.
      * @param baseRetryDelay base sleep interval for exponential backoff in case of retryable exceptions. defaults to 10s.
      */
 

--- a/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/StandardRetryPolicy.java
@@ -29,7 +29,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     private final int maxRetries;
 
-    private static final int DEFAULT_MAX_RETRIES = 6;
+    private static final int DEFAULT_MAX_RETRIES = 7;
 
     public StandardRetryPolicy()
     {
@@ -38,7 +38,7 @@ public class StandardRetryPolicy implements RetryPolicy
 
     public StandardRetryPolicy(int maxRetries)
     {
-        this.maxRetries = Math.min(6, maxRetries);
+        this.maxRetries = Math.min(7, maxRetries);
     }
 
     @SuppressWarnings("SimplifiableIfStatement")


### PR DESCRIPTION
Keeping the changes consistent with py-sdk, https://github.com/qubole/qds-sdk-py/pull/317 , updating default/max retries to 7 in case of retriable exceptions.