### PR TITLE
parameters for command api

### DIFF
--- a/src/main/java/com/qubole/qds/sdk/java/api/CommandApi.java
+++ b/src/main/java/com/qubole/qds/sdk/java/api/CommandApi.java
@@ -20,6 +20,7 @@ import com.qubole.qds.sdk.java.entities.CommandResponse;
 import com.qubole.qds.sdk.java.entities.Commands;
 
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 /**
  * Corresponds to http://www.qubole.com/docs/documentation/command-api/
@@ -161,4 +162,7 @@ public interface CommandApi
     public CommandApi includeQueryProperties(boolean includeQueryProperties);
 
     public CommandApi endDate(String endDate);
+
+    public CommandApi commandType(List<BaseCommand.COMMAND_TYPE> commandTypes);
+
 }

--- a/src/main/java/com/qubole/qds/sdk/java/details/CommandApiImpl.java
+++ b/src/main/java/com/qubole/qds/sdk/java/details/CommandApiImpl.java
@@ -26,7 +26,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import javax.ws.rs.core.Response;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 
 class CommandApiImpl implements CommandApi
 {
@@ -186,4 +191,15 @@ class CommandApiImpl implements CommandApi
         return this;
     }
 
+    @Override
+    public CommandApi commandType(List<BaseCommand.COMMAND_TYPE> commandTypes) {
+
+        String commandTypeCsv = commandTypes.stream()
+                .filter(type -> type != BaseCommand.COMMAND_TYPE.NONE)
+                .map(i -> UPPER_UNDERSCORE.to(UPPER_CAMEL, i + "_COMMAND"))
+                .collect(Collectors.joining(","));
+
+        parameters.put("command_type", commandTypeCsv);
+        return this;
+    }
 }

--- a/src/test/java/com/qubole/qds/sdk/java/TestClient.java
+++ b/src/test/java/com/qubole/qds/sdk/java/TestClient.java
@@ -15,12 +15,13 @@
  */
 package com.qubole.qds.sdk.java;
 
+import com.google.common.collect.ImmutableList;
+import com.qubole.qds.sdk.java.api.BaseCommand;
 import com.qubole.qds.sdk.java.client.DefaultQdsConfiguration;
 import com.qubole.qds.sdk.java.client.QdsConfiguration;
 import com.qubole.qds.sdk.java.details.RequestDetails;
 import com.qubole.qds.sdk.java.details.ForPage;
 import com.qubole.qds.sdk.java.details.QdsClientImpl;
-import org.apache.http.client.utils.URIBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import javax.ws.rs.client.AsyncInvoker;
@@ -98,13 +99,21 @@ public class TestClient
         String endDate = "2018-07-13T23:59:59Z";
         boolean allUsers = false;
         boolean qProps = false;
-        client.command().startDate(startDate).endDate(endDate).allUsers(allUsers).includeQueryProperties(qProps).history().invoke();
+
+        client.command()
+                .startDate(startDate)
+                .endDate(endDate)
+                .allUsers(allUsers)
+                .commandType(ImmutableList.of(BaseCommand.COMMAND_TYPE.HIVE, BaseCommand.COMMAND_TYPE.PRESTO))
+                .includeQueryProperties(qProps).history().invoke();
+
         WebTarget webTarget = webTargetReference.get();
         Assert.assertNotNull(webTarget);
         Assert.assertTrue(webTarget.getUri().toString().contains("end_date="+endDate.replaceAll(":", "%3A")));
         Assert.assertTrue(webTarget.getUri().toString().contains("include_query_properties="+qProps));
         Assert.assertTrue(webTarget.getUri().toString().contains("all_users="+0));
         Assert.assertTrue(webTarget.getUri().toString().contains("start_date="+startDate.replaceAll(":", "%3A")));
+        Assert.assertTrue(webTarget.getUri().toString().contains("command_type=HiveCommand%2CPrestoCommand"));
     }
 
 


### PR DESCRIPTION
Problem:
client.command().history().invoke(); currently lists all commands from that user. But need to have ability to provide parameters for command type (say hive, presto...)

https://docs.qubole.com/en/latest/rest-api/command_api/view-command-history.html - Rest API already supports that -

-d '{"command_type":"ShellCommand,HiveCommand", "name":"named_command"}' \
"https://api.qubole.com/api/v1.2/commands" 

https://github.com/qubole/qds-sdk-java/issues/118